### PR TITLE
make style no longer global

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -36,7 +36,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
 .scrollable {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
**Context**
Card: https://app.asana.com/0/1126434277571275/1153261367158663

Jeff noticed that the register page on freshcard was spacing the inputs super widely and then condensing them when you clicked on one of the inputs. 

I tracked the problem to this pr: https://github.com/propelinc/freshcard/pull/354/files where I added vue phoenix to freshcard. 

I then tracked the problem to the CmsZone's <style> object. Specifically the `flex 1 1 auto` in this block:
```
.scrollable-content {	.scrollable-content {
  height: 100%;	  height: 100%;
  width: 100%;	  width: 100%;
  flex: 1 1 auto;	  flex: 1 1 auto;
  position: relative; /* need this to position inner content */	  position: relative; /* need this to position inner content */
  overflow-y: auto;	  overflow-y: auto;
  -webkit-overflow-scrolling: touch;	  -webkit-overflow-scrolling: touch;
}
```

From [here](https://vue-loader.vuejs.org/guide/scoped-css.html) the issue seems to be that if you don't specify scoped on your style tags, the styling is applied globaly. The fix seems to be to just ensure that the styling for this component is scoped instead of global. 

Having said all of that, I am confused on why this `scrollable` style stuff is in the CMS zone at all? Can you provide some context there? 