### PR TITLE
Fix regression in v-track-click directive.

### DIFF
--- a/src/directives.ts
+++ b/src/directives.ts
@@ -98,20 +98,21 @@ const trackClick: DirectiveOptions =  {
       pluginOptions.trackClickHandler(el.attrs['event-name'], el.attrs['event-props'] || {});
     };
     el.addEventListener('click', wrappedHandler);
-    el.$destroy = (): void => el.removeEventListener('click', wrappedHandler);
+    el.$destroy = (): void => {
+      el.removeEventListener('click', wrappedHandler);
+      delete el.attrs;
+    }
   },
   update(el: DestroyHTMLElementWithAttrs, binding: DirectiveBinding, vnode: VNode): void {
     el.attrs = vnode.data && vnode.data.attrs ? vnode.data.attrs: {};
   },
   unbind(el: DestroyHTMLElementWithAttrs): void {
-    // When using both a v-track-click directive and an @click handler you can run into a race condition.
-    // The @click handler fires first. If that @click handler leads to the DOM element being removed from the DOM,
-    // the unbind call will run before the track-click handler is run. This leads to the click handler
+    // A race condition occurs when using both a v-track-click directive and an @click handler.
+    // If the @click handler removes the element from the DOM, the directive unbind
+    // runs before the track-click handler can run. This leads to the v-track-click handler
     // being removed before it can fire.
-    //
-    // To fix that issue, we are using a setTimeout of 0. This allows the click handler to execute
-    // before it is removed.
-    delete el.attrs;
+
+    // The setTimeout allows the click handler to execute before it is removed.
     setTimeout((): void => {
       el.$destroy();
     }, 0);

--- a/tests/unit/directives.spec.ts
+++ b/tests/unit/directives.spec.ts
@@ -50,7 +50,7 @@ describe('v-track-click directives', (): void => {
     expect(pluginOptions.trackClickHandler).toHaveBeenCalledWith(testCase.eventName, { foo: 'car' });
   });
 
-  it('tracks an event on click', async (): Promise<void> => {
+  it('tracks an event on click even if element is removed from the DOM', async (): Promise<void> => {
     const testCase = {
       template: `<div v-if="eventProps.foo == 'bar'" v-track-click @click="eventProps.foo = 'car'" event-name="kamehameha" :event-props="eventProps"></div>`,
       eventName: 'kamehameha',

--- a/tests/unit/directives.spec.ts
+++ b/tests/unit/directives.spec.ts
@@ -43,10 +43,31 @@ describe('v-track-click directives', (): void => {
     console.error = jest.fn();
     wrapper.find('div').trigger('click');
 
-    expect(pluginOptions.trackClickHandler).toHaveBeenCalledWith(testCase.eventName, testCase.eventProps);
+    expect(pluginOptions.trackClickHandler).toHaveBeenCalledWith(testCase.eventName, { foo: 'bar' });
     testCase.eventProps.foo = 'car';
     await Vue.nextTick();
 
-    expect(pluginOptions.trackClickHandler).toHaveBeenCalledWith(testCase.eventName, testCase.eventProps);
+    expect(pluginOptions.trackClickHandler).toHaveBeenCalledWith(testCase.eventName, { foo: 'car' });
+  });
+
+  it('tracks an event on click', async (): Promise<void> => {
+    const testCase = {
+      template: `<div v-if="eventProps.foo == 'bar'" v-track-click @click="eventProps.foo = 'car'" event-name="kamehameha" :event-props="eventProps"></div>`,
+      eventName: 'kamehameha',
+      eventProps: { foo: 'bar' },
+    };
+
+    const component = Vue.extend({
+      template: testCase.template,
+      data: () => ({ eventProps: testCase.eventProps }),
+    });
+    const wrapper = shallowMount(component, { localVue });
+    expect(pluginOptions.trackClickHandler).not.toHaveBeenCalled();
+
+    console.error = jest.fn();
+    wrapper.find('div').trigger('click');
+
+    await Vue.nextTick();
+    expect(pluginOptions.trackClickHandler).toHaveBeenCalledWith(testCase.eventName, { foo: 'car' });
   });
 });


### PR DESCRIPTION
The previous commit (https://github.com/propelinc/vue-phoenix/commit/052f0cf3040487cb15bd046e5f61e377b466a011) introduced a regression when v-track-click is used with @click. This PR adds a test for this case and fixes the regression.