### PR TITLE
Allow jest to import vue-phoenix when npm installed.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,9 @@
 import Vue from 'vue';
 
 import CmsPlugin, { CmsOptions } from './main';
+import './components/capture';
+import './directives';
+import './utils';
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> extends CmsOptions {}


### PR DESCRIPTION
This change allows us to fix the failing unit tests in freshebt-vue.