### PR TITLE
Make Axios peer dependency less stringent

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "types": "types/index.d.ts",
   "peerDependencies": {
-    "axios": "^0.18.0",
+    "axios": ">= 0.18.0",
     "jquery": "^3.3.1",
     "lodash": "^4.17.11",
     "vue": "^2.6.8",


### PR DESCRIPTION
We're using 0.19.0 in `freshcard-app` and I'd like to suppress the npm warning.

```
npm WARN vue-phoenix@1.0.0 requires a peer of axios@^0.18.0 but none is installed. You must install peer dependencies yourself.```