### PR TITLE
Add function to change server URL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,8 @@
-import CmsPlugin, { Content, HTMLContent } from './src/main';
+import CmsPlugin, { Content, HTMLContent, setBaseUrl } from './src/main';
 
 
 export { getClosest } from './src/utils';
+export { setBaseUrl };
 
 export type CmsContent = Content;
 export type CmsHtmlContent = HTMLContent;

--- a/src/cmsHttp.ts
+++ b/src/cmsHttp.ts
@@ -123,6 +123,9 @@ class CmsClient {
     await this.http({ zoneId, url: content.tracker });
   }
 
+  setBaseUrl(url: string) {
+    this.axios.defaults.baseURL = url;
+  }
 }
 
 export default new CmsClient();

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import CmsContent from './components/CmsContent';
 import CmsCarousel from './components/CmsCarousel.vue';
 import CmsZone from './components/CmsZone.vue';
 import { addDirectives } from './directives';
+import cmsClient from './cmsHttp';
 
 export interface Captable {
 }
@@ -99,6 +100,11 @@ export const pluginOptions: PluginOptions = {
   },
 };
 export var finalPluginOptions: PluginOptions;
+
+export function setBaseUrl(url: string) {
+  pluginOptions.baseUrl = url;
+  cmsClient.setBaseUrl(url);
+}
 
 const plugin = function install(Vue: typeof _Vue, options?: CmsOptions) {
   Object.assign(pluginOptions, options);

--- a/tests/unit/cmsHttp.spec.ts
+++ b/tests/unit/cmsHttp.spec.ts
@@ -1,0 +1,12 @@
+import cmsClient from '../../src/cmsHttp';
+import { pluginOptions } from '../../src/main';
+
+describe('cmsHttp.ts', () => {
+  it('can update the base URL', () => {
+    pluginOptions.baseUrl = '/test/url';
+    expect(cmsClient.axios.defaults.baseURL).toBe('/test/url');
+    
+    cmsClient.setBaseUrl('/new/test/url')
+    expect(cmsClient.axios.defaults.baseURL).toBe('/new/test/url');
+  })
+});

--- a/tests/unit/main.spec.ts
+++ b/tests/unit/main.spec.ts
@@ -1,0 +1,14 @@
+import cmsClient from '../../src/cmsHttp';
+import { pluginOptions, setBaseUrl } from '../../src/main';
+
+describe('main.ts', () => {
+  it('updates the base URL in plugin options and http client', () => {
+    pluginOptions.baseUrl = '/test/url';
+    cmsClient.setBaseUrl = jest.fn();
+    
+    setBaseUrl('/new/test/url');
+
+    expect(pluginOptions.baseUrl).toBe('/new/test/url');
+    expect(cmsClient.setBaseUrl).toHaveBeenCalledWith('/new/test/url');
+  })
+});


### PR DESCRIPTION
Allows us to change the server URLs hit by the CMS Axios client while Fresh EBT is running. 

Part of work for https://app.asana.com/0/1158105657996916/1157538072422361