### PR TITLE
Add support for a zone type that paginates content upon scroll.

### DIFF
--- a/src/cmsHttp.ts
+++ b/src/cmsHttp.ts
@@ -83,7 +83,7 @@ class CmsClient {
     }
   }
 
-  async fetchZone({ zoneId, extra, page }: { zoneId: string, extra: object, page?: number }) {
+  async fetchZone({ zoneId, extra, cursor }: { zoneId: string, extra: object, cursor?: string }) {
     if (pluginOptions.beforeFetchZone) {
       await pluginOptions.beforeFetchZone();
     }
@@ -95,7 +95,7 @@ class CmsClient {
       url: `/cms/zone/${zoneId}`,
       params: {
         cb: Math.floor(Math.random() * 999999999),
-        page: page,
+        cursor: cursor,
         ...pluginOptions.getSiteVars(),
         ...extra,
       },

--- a/src/cmsHttp.ts
+++ b/src/cmsHttp.ts
@@ -83,7 +83,7 @@ class CmsClient {
     }
   }
 
-  async fetchZone({ zoneId, extra }: { zoneId: string, extra: object }) {
+  async fetchZone({ zoneId, extra, page }: { zoneId: string, extra: object, page?: number }) {
     if (pluginOptions.beforeFetchZone) {
       await pluginOptions.beforeFetchZone();
     }
@@ -95,6 +95,7 @@ class CmsClient {
       url: `/cms/zone/${zoneId}`,
       params: {
         cb: Math.floor(Math.random() * 999999999),
+        page: page,
         ...pluginOptions.getSiteVars(),
         ...extra,
       },

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -1,12 +1,12 @@
 <template>
   <div
-    :class="{ 'scrollable-content': isScrolling }"
     v-infinite-scroll="{ action: next, enabled: isScrolling }"
+    :class="{ 'scrollable-content': isScrolling }"
   >
     <slot v-if="!zoneType && !contents.length" />
-    <slot v-if="zoneStatus === 'error'" name="error"></slot>
-    <slot v-if="zoneStatus === 'offline'" name="offline"></slot>
-    <slot v-if="zoneStatus === 'loading'" name="loading"></slot>
+    <slot v-if="zoneStatus === 'error'" name="error" />
+    <slot v-if="zoneStatus === 'offline'" name="offline" />
+    <slot v-if="zoneStatus === 'loading'" name="loading" />
     <div v-if="contents.length">
       <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
       <cms-carousel
@@ -37,7 +37,7 @@
           :zone-id="zoneId"
         />
       </div>
-      <slot v-if="cursorLoading" name="cursor"></slot>
+      <slot v-if="cursorLoading" name="cursor" />
       <cms-content v-if="zoneFooter" :html="zoneFooter" :zone-id="zoneId" />
     </div>
   </div>
@@ -67,8 +67,8 @@
 </style>
 
 <script lang="ts">
-import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 
 import { Content } from '../api';
@@ -112,7 +112,7 @@ export default class CmsZone extends Vue {
   public next = debounce(() => this.getNextPage(), 400);
 
   private get isScrolling() {
-    return this.zoneType === 'scrolling'; 
+    return this.zoneType === 'scrolling';
   }
 
   private created(): void {

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -3,7 +3,13 @@
     :class="{ 'scrollable-content': isScrolling }"
     v-infinite-scroll="{ action: next, enabled: isScrolling }"
   >
+    <!-- Default slot uses css classes. Deprecated, use the named slots instead. -->
     <slot v-if="!zoneType && !contents.length" />
+
+    <slot v-if="zoneStatus === 'error'" name="error"></slot>
+    <slot v-if="zoneStatus === 'offline'" name="offline"></slot>
+    <slot v-if="zoneStatus === 'loading'" name="loading"></slot>
+
     <div v-if="contents.length">
       <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
       <cms-carousel
@@ -45,6 +51,9 @@
           :zone-id="zoneId"
         />
       </div>
+
+      <slot v-if="cursorLoading" name="cursor"></slot>
+
       <cms-content v-if="zoneFooter" :html="zoneFooter" :zone-id="zoneId" />
     </div>
   </div>
@@ -106,6 +115,7 @@ export default class CmsZone extends Vue {
   @Prop(String) public zoneId!: string;
   @Prop(Object) public extra!: {};
 
+  public zoneStatus: string | null = null;
   public zoneType: string = '';
   public zoneHeader: string = '';
   public zoneFooter: string = '';
@@ -113,6 +123,8 @@ export default class CmsZone extends Vue {
   public cursor: string = '';
   public scrollable: Element | null = null;
   public scrollableListeners: EventListener[] = [];
+
+  public cursorLoading: boolean = false;
   public next = debounce(() => this.getNextPage(), 400);
 
   private get isScrolling() {
@@ -161,6 +173,7 @@ export default class CmsZone extends Vue {
 
   private async refresh(): Promise<void> {
     if (!pluginOptions.checkConnection()) {
+      this.zoneStatus = 'offline';
       this.$el.classList.add('cms-zone-offline');
       this.$el.classList.remove('cms-zone-error');
       this.$el.classList.remove('cms-zone-loading');
@@ -168,6 +181,7 @@ export default class CmsZone extends Vue {
       return;
     }
 
+    this.zoneStatus = 'loading';
     this.$el.classList.add('cms-zone-loading');
     this.$el.classList.remove('cms-zone-error');
     this.$el.classList.remove('cms-zone-offline');
@@ -180,6 +194,7 @@ export default class CmsZone extends Vue {
         throw new Error('No data');
       }
     } catch (error) {
+      this.zoneStatus = 'error';
       this.$el.classList.remove('cms-zone-loading');
       this.$el.classList.add('cms-zone-error');
       this.zoneType = '';
@@ -192,6 +207,7 @@ export default class CmsZone extends Vue {
     this.cursor = data.cursor;
     this.zoneHeader = data.zone_header ? `<div class="zone-header">${data.zone_header || ''}</div>` : '';
     this.zoneFooter = data.zone_footer ? `<div class="zone-footer">${data.zone_footer || ''}</div>` : '';
+    this.zoneStatus = null;
 
     if (!this.contents.length) {
       return;
@@ -281,7 +297,7 @@ export default class CmsZone extends Vue {
       return;
     }
 
-    this.$el.classList.add('cms-zone-cursor-loading');
+    this.cursorLoading = true;
 
     let response;
     try {
@@ -296,7 +312,7 @@ export default class CmsZone extends Vue {
         this.trackScrollable(newContents, this.scrollable);
       }
     } catch (error) {
-      this.$el.classList.remove('cms-zone-cursor-loading');
+      this.cursorLoading = false;
     }
   }
 

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -107,7 +107,7 @@ export default class CmsZone extends Vue {
   public zoneHeader: string = '';
   public zoneFooter: string = '';
   public contents: Content[] = [];
-  public page: number = 0;
+  public cursor: string = '';
   public scrollable: Element | null = null;
   public scrollableListeners: EventListener[] = [];
   public next = debounce(this.getNextPage, 400);
@@ -182,6 +182,7 @@ export default class CmsZone extends Vue {
     const data = response.data;
     this.zoneType = data.zone_type;
     this.contents = data.content as Content[];
+    this.cursor = data.cursor;
     this.zoneHeader = data.zone_header ? `<div class="zone-header">${data.zone_header || ''}</div>` : '';
     this.zoneFooter = data.zone_footer ? `<div class="zone-footer">${data.zone_footer || ''}</div>` : '';
 
@@ -269,11 +270,11 @@ export default class CmsZone extends Vue {
   }
 
   private async getNextPage() {
-    this.page++;
-    const response = await cmsClient.fetchZone({ zoneId: this.zoneId, extra: this.extra, page: this.page });
+    const response = await cmsClient.fetchZone({ zoneId: this.zoneId, extra: this.extra, cursor: this.cursor });
     if (!response.data || !response.data.content) {
       throw new Error('No data');
     }
+    this.cursor = response.data.cursor;
     this.contents.push(...response.data.content as Content[]);
   }
 

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -277,12 +277,27 @@ export default class CmsZone extends Vue {
   }
 
   private async getNextPage() {
-    const response = await cmsClient.fetchZone({ zoneId: this.zoneId, extra: this.extra, cursor: this.cursor });
-    if (!response.data || !response.data.content) {
-      throw new Error('No data');
+    if (!pluginOptions.checkConnection()) {
+      return;
     }
-    this.cursor = response.data.cursor;
-    this.contents.push(...response.data.content as Content[]);
+
+    this.$el.classList.add('cms-zone-cursor-loading');
+
+    let response;
+    try {
+      response = await cmsClient.fetchZone({ zoneId: this.zoneId, extra: this.extra, cursor: this.cursor });
+      if (!response.data || !response.data.content) {
+        throw new Error('No data');
+      }
+      this.cursor = response.data.cursor;
+      const newContents = response.data.content as Content[];
+      this.contents.push(...newContents);
+      if (this.scrollable) {
+        this.trackScrollable(newContents, this.scrollable);
+      }
+    } catch (error) {
+      this.$el.classList.remove('cms-zone-cursor-loading');
+    }
   }
 
   private isContentVisible(el: Element, viewport: Element, minPercentVisible: number): boolean {

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="{ 'scrollable-content': isScrolling }"
-    v-infinite-scroll[isInfiniteScrollDisabled]="next"
+    v-infinite-scroll:[isInfiniteScrollDisabled]="next"
   >
     <slot v-if="!zoneType && !contents.length" />
     <div v-if="contents.length">

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -29,17 +29,6 @@
           :zone-id="zoneId"
         />
       </cms-carousel>
-      <div v-else-if="zoneType === 'scrolling'" class="zone-contents">
-        <cms-content
-          v-for="(content, index) in contents"
-          :key="index"
-          :class="`cms-zone-content-${zoneId}-${index}`"
-          tag="div"
-          :html="content.html"
-          :extra="extra"
-          :zone-id="zoneId"
-        />
-      </div>
       <div v-else class="zone-contents">
         <cms-content
           v-for="(content, index) in contents"

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -311,7 +311,7 @@ export default class CmsZone extends Vue {
       if (this.scrollable) {
         this.trackScrollable(newContents, this.scrollable);
       }
-    } catch (error) {
+    } finally {
       this.cursorLoading = false;
     }
   }

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -281,6 +281,10 @@ export default class CmsZone extends Vue {
       return;
     }
 
+    if (this.cursorLoading) {
+      return;
+    }
+
     this.cursorLoading = true;
 
     let response;

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -120,7 +120,8 @@ export default class CmsZone extends Vue {
   }
 
   private get isInfiniteScrollDisabled() {
-    return this.isScrolling ? '-' : '';
+    // Setting the tolerance to '-' disables the v-infinite-scroll directive.
+    return this.isScrolling ? '' : '-';
   }
 
   private created(): void {

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="{ 'scrollable-content': isScrolling }"
-    v-infinite-scroll:[isInfiniteScrollDisabled]="next"
+    v-infinite-scroll="{ action: next, enabled: isScrolling }"
   >
     <slot v-if="!zoneType && !contents.length" />
     <div v-if="contents.length">
@@ -113,15 +113,10 @@ export default class CmsZone extends Vue {
   public cursor: string = '';
   public scrollable: Element | null = null;
   public scrollableListeners: EventListener[] = [];
-  public next = debounce(this.getNextPage, 400);
+  public next = debounce(() => this.getNextPage(), 400);
 
   private get isScrolling() {
     return this.zoneType === 'scrolling'; 
-  }
-
-  private get isInfiniteScrollDisabled() {
-    // Setting the tolerance to '-' disables the v-infinite-scroll directive.
-    return this.isScrolling ? '' : '-';
   }
 
   private created(): void {

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    :class="{ 'scrollable-content': isScrolling }"
+    v-infinite-scroll[isInfiniteScrollDisabled]="next"
+  >
     <slot v-if="!zoneType && !contents.length" />
     <div v-if="contents.length">
       <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
@@ -20,7 +23,7 @@
           :zone-id="zoneId"
         />
       </cms-carousel>
-      <div v-else-if="zoneType === 'scrolling'" v-infinite-scroll="next" class="scrollable-content zone-contents">
+      <div v-else-if="zoneType === 'scrolling'" class="zone-contents">
         <cms-content
           v-for="(content, index) in contents"
           :key="index"
@@ -111,6 +114,14 @@ export default class CmsZone extends Vue {
   public scrollable: Element | null = null;
   public scrollableListeners: EventListener[] = [];
   public next = debounce(this.getNextPage, 400);
+
+  private get isScrolling() {
+    return this.zoneType === 'scrolling'; 
+  }
+
+  private get isInfiniteScrollDisabled() {
+    return this.isScrolling ? '-' : '';
+  }
 
   private created(): void {
     this.$root.$on('cms.refresh', this.refresh);

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -3,13 +3,10 @@
     :class="{ 'scrollable-content': isScrolling }"
     v-infinite-scroll="{ action: next, enabled: isScrolling }"
   >
-    <!-- Default slot uses css classes. Deprecated, use the named slots instead. -->
     <slot v-if="!zoneType && !contents.length" />
-
     <slot v-if="zoneStatus === 'error'" name="error"></slot>
     <slot v-if="zoneStatus === 'offline'" name="offline"></slot>
     <slot v-if="zoneStatus === 'loading'" name="loading"></slot>
-
     <div v-if="contents.length">
       <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
       <cms-carousel
@@ -40,9 +37,7 @@
           :zone-id="zoneId"
         />
       </div>
-
       <slot v-if="cursorLoading" name="cursor"></slot>
-
       <cms-content v-if="zoneFooter" :html="zoneFooter" :zone-id="zoneId" />
     </div>
   </div>

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -55,7 +55,7 @@ function setupInfiniteScroll(el: DestroyHTMLElement, binding: DirectiveBinding) 
     if (el.scrollTop >= el.clientHeight - tolerance) {
       action();
     }
-  }
+  };
 
   el.bound = true;
   el.addEventListener('scroll', handler);

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -25,15 +25,19 @@ const infiniteScroll: DirectiveOptions = {
       : { action: binding.value, enabled: true };
 
     if (!params.enabled) {
+      console.info('DISABLED inf scrolling');
       return;
     }
 
     const tolerance = parseInt(binding.arg || '100', 10);
     const action = params.action;
 
+    console.info('SETUP inf scrolling');
     el.addEventListener('scroll', (): void => {
+      console.info('SCROLLEVENT inf scrolling');
       const height = (el.firstChild as DestroyHTMLElement).clientHeight;
       if (el.scrollTop >= height - el.clientHeight - tolerance) {
+        console.info('CALC SUCCESS inf scrolling');
         action();
       }
     });

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -51,12 +51,8 @@ function setupInfiniteScroll(el: DestroyHTMLElement, binding: DirectiveBinding) 
   const tolerance = parseInt(binding.arg || '100', 10);
   const action = params.action;
 
-  console.info('SETUP inf scrolling');
   const handler = (): void => {
-    console.info('SCROLLEVENT inf scrolling');
-    const height = (el.firstChild as DestroyHTMLElement).clientHeight;
-    if (el.scrollTop >= height - el.clientHeight - tolerance) {
-      console.info('CALC SUCCESS inf scrolling');
+    if (el.scrollTop >= el.clientHeight - tolerance) {
       action();
     }
   }

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -5,17 +5,19 @@ import { pluginOptions } from './plugins/cms';
 import { getClosest } from './utils';
 
 interface DestroyHTMLElement extends HTMLElement {
-  $destroy: () => void;
+  $destroy?: () => void;
   bound?: boolean;
   attrs?: object;
 }
 
 interface DestroyHTMLInputElement extends HTMLInputElement {
-  $destroy: () => void;
+  $destroy?: () => void;
 }
 
 function destroy(el: DestroyHTMLElement): void {
-  el.$destroy();
+  if (el.$destroy) {
+    el.$destroy();
+  }
 }
 
 /**

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -20,6 +20,9 @@ interface DestroyHTMLInputElement extends HTMLInputElement {
  */
 const infiniteScroll: DirectiveOptions = {
   bind(el: DestroyHTMLElement, binding: DirectiveBinding): void {
+    if (binding.arg === '-') {
+      return;
+    }
     const tolerance = parseInt(binding.arg || '100', 10);
     const action = binding.value;
 

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -20,11 +20,16 @@ interface DestroyHTMLInputElement extends HTMLInputElement {
  */
 const infiniteScroll: DirectiveOptions = {
   bind(el: DestroyHTMLElement, binding: DirectiveBinding): void {
-    if (binding.arg === '-') {
+    const params = typeof binding.value === 'object'
+      ? binding.value
+      : { action: binding.value, enabled: true };
+
+    if (!params.enabled) {
       return;
     }
+
     const tolerance = parseInt(binding.arg || '100', 10);
-    const action = binding.value;
+    const action = params.action;
 
     el.addEventListener('scroll', (): void => {
       const height = (el.firstChild as DestroyHTMLElement).clientHeight;

--- a/src/plugins/planout.ts
+++ b/src/plugins/planout.ts
@@ -1,5 +1,5 @@
 import Axios, { AxiosInstance } from 'axios';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import {
   Assignment, Experiment, ExperimentSetup,
   Inputs, Interpreter, PlanoutCode, Namespace,

--- a/tests/unit/CmsZone.spec.ts
+++ b/tests/unit/CmsZone.spec.ts
@@ -74,7 +74,7 @@ describe('CmsZone.vue', (): void => {
     }
   });
 
-  ['default', 'carousel'].forEach((zoneType): void => {
+  ['default', 'carousel', 'scrolling'].forEach((zoneType): void => {
     it(`renders empty state for ${zoneType} zone`, async (): Promise<void> => {
       const zoneId = '5';
       const extra = { foo: 'bar' };

--- a/tests/unit/CmsZone.spec.ts
+++ b/tests/unit/CmsZone.spec.ts
@@ -87,7 +87,8 @@ describe('CmsZone.vue', (): void => {
       resolvePromise(makeResponse(zoneType, []));
       await response;
       await localVue.nextTick();
-      expect(wrapper.classes()).toEqual([]);
+      const expectedClasses = zoneType === 'scrolling' ? ['scrollable-content'] : [];
+      expect(wrapper.classes()).toEqual(expectedClasses);
       expect(wrapper.text()).toBe('');
       expect(wrapper.text()).not.toMatch('Some header');
       expect(wrapper.text()).not.toMatch('Some footer');
@@ -105,7 +106,8 @@ describe('CmsZone.vue', (): void => {
       resolvePromise(makeResponse(zoneType, [{ html: '<div>Some Content</div>', tracker: 'foo' }]));
       await response;
       await localVue.nextTick();
-      expect(wrapper.classes()).toEqual([]);
+      const expectedClasses = zoneType === 'scrolling' ? ['scrollable-content'] : [];
+      expect(wrapper.classes()).toEqual(expectedClasses);
       expect(cmsClient.trackZone).toHaveBeenCalled();
       expect(wrapper.find('.cms-zone-contents-5-0')).toBeTruthy();
       expect(wrapper.text()).toMatch('Some header');

--- a/tests/unit/directives.spec.ts
+++ b/tests/unit/directives.spec.ts
@@ -134,7 +134,7 @@ describe('v-init', () => {
 
 describe('v-infinite-scroll', () => {
 
-  function createComponent(enabled: boolean = true) {
+  function createComponent(template?: string, enabled: boolean = true) {
     return Vue.extend({
       data: function() {
         return {
@@ -147,7 +147,7 @@ describe('v-infinite-scroll', () => {
           this.text = 'after';
         },
       },
-      template: `
+      template: template || `
         <div class="scrollable">
           <div v-infinite-scroll="{ enabled, action }" class="scrollable-content">
             {{ text }}
@@ -165,10 +165,23 @@ describe('v-infinite-scroll', () => {
   });
 
   it('does nothing when disabled', () => {
-    const testComponent = createComponent(false);
+    const testComponent = createComponent(undefined, false);
     const wrapper = shallowMount(testComponent, { localVue });
     expect(wrapper.vm.$data.text).toEqual('before');
     wrapper.find('.scrollable-content').trigger('scroll');
     expect(wrapper.vm.$data.text).toEqual('before');
+  });
+
+  it('invokes the action when binding value is a function', () => {
+    const template = `
+      <div class="scrollable">
+        <div v-infinite-scroll="action" class="scrollable-content">{{ text }}
+        </div>
+      </div>`
+    const testComponent = createComponent(template);
+    const wrapper = shallowMount(testComponent, { localVue });
+    expect(wrapper.vm.$data.text).toEqual('before');
+    wrapper.find('.scrollable-content').trigger('scroll');
+    expect(wrapper.vm.$data.text).toEqual('after');
   });
 });

--- a/tests/unit/directives.spec.ts
+++ b/tests/unit/directives.spec.ts
@@ -120,7 +120,7 @@ describe('v-track-render tests', (): void => {
 });
 
 describe('v-init', () => {
-  it('v-init sets the correct values', () => {
+  it('sets the correct values', () => {
     const testComponent = Vue.extend({
       data: function() {
         return { context: {} };
@@ -129,5 +129,46 @@ describe('v-init', () => {
     });
     const wrapper = shallowMount(testComponent, { localVue });
     expect(wrapper.vm.$data.context).toEqual({ hello: 'world' });
+  });
+});
+
+describe('v-infinite-scroll', () => {
+
+  function createComponent(enabled: boolean = true) {
+    return Vue.extend({
+      data: function() {
+        return {
+          text: 'before',
+          enabled,
+        };
+      },
+      methods: {
+        action() {
+          this.text = 'after';
+        },
+      },
+      template: `
+        <div class="scrollable">
+          <div v-infinite-scroll="{ enabled, action }" class="scrollable-content">
+            {{ text }}
+          </div>
+        </div>`,
+    });
+  }
+
+  it('invokes the action method on scroll', () => {
+    const testComponent = createComponent();
+    const wrapper = shallowMount(testComponent, { localVue });
+    expect(wrapper.vm.$data.text).toEqual('before');
+    wrapper.find('.scrollable-content').trigger('scroll');
+    expect(wrapper.vm.$data.text).toEqual('after');
+  });
+
+  it('does nothing when disabled', () => {
+    const testComponent = createComponent(false);
+    const wrapper = shallowMount(testComponent, { localVue });
+    expect(wrapper.vm.$data.text).toEqual('before');
+    wrapper.find('.scrollable-content').trigger('scroll');
+    expect(wrapper.vm.$data.text).toEqual('before');
   });
 });

--- a/tests/unit/directives.spec.ts
+++ b/tests/unit/directives.spec.ts
@@ -133,7 +133,6 @@ describe('v-init', () => {
 });
 
 describe('v-infinite-scroll', () => {
-
   function createComponent(template?: string, enabled: boolean = true) {
     return Vue.extend({
       data: function() {
@@ -177,7 +176,7 @@ describe('v-infinite-scroll', () => {
       <div class="scrollable">
         <div v-infinite-scroll="action" class="scrollable-content">{{ text }}
         </div>
-      </div>`
+      </div>`;
     const testComponent = createComponent(template);
     const wrapper = shallowMount(testComponent, { localVue });
     expect(wrapper.vm.$data.text).toEqual('before');


### PR DESCRIPTION
* Updates the v-infinite-scroll directive logic to unbind properly.
* Changes to CmsZone are backward compatible.
* Provides a named slot based alternative for defining offline, loading, and error states for a component.
* This will substantially increase the performance for zones that house a lot of eligible content (e.g. recipes, all offers).
* Server side PR that adds cursor support.
* https://github.com/propelinc/freshebt-server/pull/1586/files