### PR TITLE
Cs test

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,3 +23,5 @@ export default {
   cms: VueCmsPlugin,
   planout: VuePlanoutPlugin,
 };
+
+console.log("STARTED");

--- a/src/components/CmsContent.ts
+++ b/src/components/CmsContent.ts
@@ -35,7 +35,7 @@ export default class CmsContent extends Vue {
 
     return h(dynamic, {
       props: { context: this.context, zoneId: this.zoneId },
-    });
+    }, this.$slots.default);
   }
 
   private renderError(h: CreateElement, err: Error): VNode {

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -8,7 +8,7 @@
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
     <div v-if="contents.length">
-      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId"/>
+      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
       <cms-carousel
         v-if="zoneType === 'carousel'"
         :center-padding="contents.length > 1 ? '20px' : '0'"
@@ -24,8 +24,8 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-          @click.native.stop.prevent="onLogoTapped(content.delivery, zoneId)">
-        </cms-content>
+          @click.native.stop.prevent="displayIds(content.delivery, zoneId)"
+        />
       </cms-carousel>
       <div v-else class="zone-contents">
         <cms-content
@@ -109,6 +109,7 @@ export default class CmsZone extends Vue {
   public scrollable: Element | null = null;
   public scrollableListeners: EventListener[] = [];
   public showContentInfo: boolean = false;
+  public tapped: number = 0;
 
   public cursorLoading: boolean = false;
   public next = debounce(() => this.getNextPage(), 400);
@@ -142,14 +143,14 @@ export default class CmsZone extends Vue {
     }
   }
 
-  private onLogoTapped(delivery_id?: any, zone_id?: any): void {
-    // alert()
-    alert("Delivery id: " + delivery_id + " Zone id: " +zone_id);
-    // this.logoTapCount++;
-    // if (this.logoTapCount === 7) {
-    //   CoreModule.SET_DEBUG_MODE(true);
-    //   this.logoTapCount = 0;
-    // }
+  private displayIds(deliveryId?: string, zoneId?: string): void {
+    console.log('HERE!');
+    this.tapped++;
+    if (this.tapped === 1) {
+      alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 
+      // CoreModule.SET_DEBUG_MODE(true);
+      this.tapped = 0;
+    }
   }
 
   @Watch('zoneId')

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -24,6 +24,7 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
+          @click.stop.prevent="onLogoTapped()"
         />
       </cms-carousel>
       <div v-else class="zone-contents">
@@ -112,7 +113,7 @@ export default class CmsZone extends Vue {
   public next = debounce(() => this.getNextPage(), 400);
 
   private get isScrolling() {
-    return this.zoneType === 'scrolling';
+    return this.zoneType === 'srolling';
   }
 
   private created(): void {
@@ -137,6 +138,15 @@ export default class CmsZone extends Vue {
       }
       this.scrollableListeners = [];
       this.scrollable = null;
+    }
+  }
+
+  private onLogoTapped(): void {
+    console.log("HEREE")
+    this.logoTapCount++;
+    if (this.logoTapCount === 1) {
+      this.logoTapCount = 0;
+      alert(`Debug mode`);
     }
   }
 

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -7,8 +7,8 @@
     <slot v-if="zoneStatus === 'error'" name="error" />
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
-    <div v-if="contents.length" @click.stop.prevent="onLogoTapped()">
-      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" @click.stop.prevent="onLogoTapped()"/>
+    <div v-if="contents.length" >
+      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
       <cms-carousel
         v-if="zoneType === 'carousel'"
         :center-padding="contents.length > 1 ? '20px' : '0'"
@@ -117,7 +117,6 @@ export default class CmsZone extends Vue {
   }
 
   private created(): void {
-    console.log("WHATS GOING ON??!")
     this.$root.$on('cms.refresh', this.refresh);
     this.$root.$on(`cms.refresh.${this.zoneId}`, this.refresh);
   }

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -147,7 +147,7 @@ export default class CmsZone extends Vue {
     console.log('HERE!' , event);
     this.tapped++;
     if (this.tapped === 1) {
-      alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 
+      // alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 
       // CoreModule.SET_DEBUG_MODE(true);
       this.tapped = 0;
     }

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -8,7 +8,7 @@
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
     <div v-if="contents.length" @click.stop.prevent="onLogoTapped()">
-      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" @click.stop.prevent="onLogoTapped()">/>
+      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" @click.stop.prevent="onLogoTapped()"/>
       <cms-carousel
         v-if="zoneType === 'carousel'"
         :center-padding="contents.length > 1 ? '20px' : '0'"

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -148,7 +148,7 @@ export default class CmsZone extends Vue {
     // debugger;
     // this.tapped++;
     // if (this.tapped === 1) {
-    //   alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 
+      alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId);
     //   // CoreModule.SET_DEBUG_MODE(true);
     //   this.tapped = 0;
     // }

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -113,10 +113,11 @@ export default class CmsZone extends Vue {
   public next = debounce(() => this.getNextPage(), 400);
 
   private get isScrolling() {
-    return this.zoneType === 'srolling';
+    return this.zoneType === 'scrolling';
   }
 
   private created(): void {
+    console.log("WHATS GOING ON??!")
     this.$root.$on('cms.refresh', this.refresh);
     this.$root.$on(`cms.refresh.${this.zoneId}`, this.refresh);
   }
@@ -142,7 +143,13 @@ export default class CmsZone extends Vue {
   }
 
   private onLogoTapped(): void {
-    alert(`Debug mode`);
+      console.log("HERERE!");
+      alert(`Debug mode: ${pluginOptions.getSiteVars()}`);
+    // this.logoTapCount++;
+    // if (this.logoTapCount === 7) {
+    //   CoreModule.SET_DEBUG_MODE(true);
+    //   this.logoTapCount = 0;
+    // }
   }
 
   @Watch('zoneId')

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -7,8 +7,8 @@
     <slot v-if="zoneStatus === 'error'" name="error" />
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
-    <div v-if="contents.length" @click.stop.prevent="onLogoTapped()">
-      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" @click.stop.prevent="onLogoTapped()"/>
+    <div v-if="contents.length">
+      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId"/>
       <cms-carousel
         v-if="zoneType === 'carousel'"
         :center-padding="contents.length > 1 ? '20px' : '0'"
@@ -24,7 +24,7 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-          @click.stop.prevent="onLogoTapped(content.id, zoneId)">
+          @click.native.stop.prevent="onLogoTapped(content.id, zoneId)">
         </cms-content>
       </cms-carousel>
       <div v-else class="zone-contents">

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -24,7 +24,7 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-          @click.native.stop.prevent="displayIds(content.delivery, zoneId, $event)"
+          @click.capture="displayIds(content.delivery, zoneId, $event)"
         />
       </cms-carousel>
       <div v-else class="zone-contents">

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -24,12 +24,7 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-<<<<<<< Updated upstream
-          @click.stop.prevent="onLogoTapped()">
-          <div v-if="contentInfo">{{ zoneId }}</div>
-=======
           @click.stop.prevent="onLogoTapped(content.id, zoneId)">
->>>>>>> Stashed changes
         </cms-content>
       </cms-carousel>
       <div v-else class="zone-contents">

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -145,6 +145,7 @@ export default class CmsZone extends Vue {
 
   private displayIds(deliveryId?: string, zoneId?: string, event?: any): void {
     console.log('HERE!' , event);
+    debugger;
     this.tapped++;
     if (this.tapped === 1) {
       // alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -8,7 +8,7 @@
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
     <div v-if="contents.length" @click.stop.prevent="onLogoTapped()">
-      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
+      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" @click.stop.prevent="onLogoTapped()">/>
       <cms-carousel
         v-if="zoneType === 'carousel'"
         :center-padding="contents.length > 1 ? '20px' : '0'"
@@ -24,6 +24,8 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
+          @click.stop.prevent="onLogoTapped()">
+          <div v-if="showContentInfo">{{ zoneId }}</div>
         />
       </cms-carousel>
       <div v-else class="zone-contents">
@@ -107,6 +109,7 @@ export default class CmsZone extends Vue {
   public cursor: string = '';
   public scrollable: Element | null = null;
   public scrollableListeners: EventListener[] = [];
+  public showContentInfo: boolean = false;
 
   public cursorLoading: boolean = false;
   public next = debounce(() => this.getNextPage(), 400);
@@ -141,8 +144,9 @@ export default class CmsZone extends Vue {
   }
 
   private onLogoTapped(): void {
-      console.log("HERERE!");
-      alert(`Debug mode: ${pluginOptions.getSiteVars()}`);
+      console.log("HERERE!", pluginOptions.getSiteVars());
+      alert(`Debug mode`);
+      this.showContentInfo = true;
     // this.logoTapCount++;
     // if (this.logoTapCount === 7) {
     //   CoreModule.SET_DEBUG_MODE(true);

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -7,8 +7,8 @@
     <slot v-if="zoneStatus === 'error'" name="error" />
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
-    <div v-if="contents.length">
-      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
+    <div v-if="contents.length" @click.stop.prevent="onLogoTapped()">
+      <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" @click.stop.prevent="onLogoTapped()"/>
       <cms-carousel
         v-if="zoneType === 'carousel'"
         :center-padding="contents.length > 1 ? '20px' : '0'"
@@ -142,12 +142,7 @@ export default class CmsZone extends Vue {
   }
 
   private onLogoTapped(): void {
-    console.log("HEREE")
-    this.logoTapCount++;
-    if (this.logoTapCount === 1) {
-      this.logoTapCount = 0;
-      alert(`Debug mode`);
-    }
+    alert(`Debug mode`);
   }
 
   @Watch('zoneId')

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -24,7 +24,7 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-          @click.native.stop.prevent="displayIds(content.delivery, zoneId)"
+          @click.native.stop.prevent="displayIds(content.delivery, zoneId, $event)"
         />
       </cms-carousel>
       <div v-else class="zone-contents">
@@ -143,8 +143,8 @@ export default class CmsZone extends Vue {
     }
   }
 
-  private displayIds(deliveryId?: string, zoneId?: string): void {
-    console.log('HERE!');
+  private displayIds(deliveryId?: string, zoneId?: string, event?: any): void {
+    console.log('HERE!' , event);
     this.tapped++;
     if (this.tapped === 1) {
       alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -24,7 +24,7 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-          @click.capture="displayIds(content.delivery, zoneId, $event)"
+          @click="displayIds(content.delivery, zoneId, $event)"
         />
       </cms-carousel>
       <div v-else class="zone-contents">
@@ -145,13 +145,13 @@ export default class CmsZone extends Vue {
 
   private displayIds(deliveryId?: string, zoneId?: string, event?: any): void {
     console.log('HERE!' , event);
-    debugger;
-    this.tapped++;
-    if (this.tapped === 1) {
-      // alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 
-      // CoreModule.SET_DEBUG_MODE(true);
-      this.tapped = 0;
-    }
+    // debugger;
+    // this.tapped++;
+    // if (this.tapped === 1) {
+    //   alert('Delivery id: ' + deliveryId + ' Zone id: ' + zoneId); 
+    //   // CoreModule.SET_DEBUG_MODE(true);
+    //   this.tapped = 0;
+    // }
   }
 
   @Watch('zoneId')

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -24,7 +24,7 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-          @click.native.stop.prevent="onLogoTapped(content.id, zoneId)">
+          @click.native.stop.prevent="onLogoTapped(content.delivery, zoneId)">
         </cms-content>
       </cms-carousel>
       <div v-else class="zone-contents">
@@ -143,7 +143,7 @@ export default class CmsZone extends Vue {
   }
 
   private onLogoTapped(delivery_id?: any, zone_id?: any): void {
-      // console.log("HERERE!", pluginOptions.getSiteVars());
+    // alert()
     alert("Delivery id: " + delivery_id + " Zone id: " +zone_id);
     // this.logoTapCount++;
     // if (this.logoTapCount === 7) {

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -24,8 +24,12 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
+<<<<<<< Updated upstream
           @click.stop.prevent="onLogoTapped()">
           <div v-if="contentInfo">{{ zoneId }}</div>
+=======
+          @click.stop.prevent="onLogoTapped(content.id, zoneId)">
+>>>>>>> Stashed changes
         </cms-content>
       </cms-carousel>
       <div v-else class="zone-contents">
@@ -143,10 +147,9 @@ export default class CmsZone extends Vue {
     }
   }
 
-  private onLogoTapped(): void {
-      console.log("HERERE!", pluginOptions.getSiteVars());
-      alert(`Debug mode`);
-      this.showContentInfo = true;
+  private onLogoTapped(delivery_id?: any, zone_id?: any): void {
+      // console.log("HERERE!", pluginOptions.getSiteVars());
+    alert("Delivery id: " + delivery_id + " Zone id: " +zone_id);
     // this.logoTapCount++;
     // if (this.logoTapCount === 7) {
     //   CoreModule.SET_DEBUG_MODE(true);

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -7,7 +7,7 @@
     <slot v-if="zoneStatus === 'error'" name="error" />
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
-    <div v-if="contents.length" >
+    <div v-if="contents.length" @click.stop.prevent="onLogoTapped()">
       <cms-content v-if="zoneHeader" :html="zoneHeader" :zone-id="zoneId" />
       <cms-carousel
         v-if="zoneType === 'carousel'"
@@ -24,7 +24,6 @@
           :html="content.html"
           :extra="extra"
           :zone-id="zoneId"
-          @click.stop.prevent="onLogoTapped()"
         />
       </cms-carousel>
       <div v-else class="zone-contents">

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -25,8 +25,8 @@
           :extra="extra"
           :zone-id="zoneId"
           @click.stop.prevent="onLogoTapped()">
-          <div v-if="showContentInfo">{{ zoneId }}</div>
-        />
+          <div v-if="contentInfo">{{ zoneId }}</div>
+        </cms-content>
       </cms-carousel>
       <div v-else class="zone-contents">
         <cms-content


### PR DESCRIPTION
Issue: Content can become more challenging to find due to the amount of content in our CMS. When a piece of content breaks we want a way to find the content in our CMS to mitigate the issue.

We want to make sure our users' do not see this feature. This should only work when the app is in debug mode. Will now be able to tap the content x times and an alert with the delivery id and zone id.


