### PR TITLE
Add empty slot to CmsZone

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -7,6 +7,7 @@
     <slot v-if="zoneStatus === 'error'" name="error" />
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
+    <slot v-if="!zoneStatus && !contents.length" name="empty" />
     <div v-if="contents.length">
       <cms-content
         v-if="zoneHeader"

--- a/tests/unit/CmsZone.spec.ts
+++ b/tests/unit/CmsZone.spec.ts
@@ -85,6 +85,25 @@ describe('CmsZone.vue', (): void => {
       expect(wrapper.text()).not.toMatch('Some footer');
     });
 
+    it(`renders empty slot for ${zoneType} zone`, async (): Promise<void> => {
+      const zoneId = '5';
+      const extra = { foo: 'bar' };
+      const wrapper = mount(CmsZone, {
+        localVue,
+        slots: { default: '<div>Default Content</div>', empty: '<div>Empty Content</div>' },
+        propsData: { zoneId, extra },
+      });
+
+      resolvePromise(makeResponse(zoneType, []));
+      await response;
+      await localVue.nextTick();
+      const expectedClasses = zoneType === 'scrolling' ? ['scrollable-content'] : [];
+      expect(wrapper.classes()).toEqual(expectedClasses);
+      expect(wrapper.text()).toBe('Empty Content');
+      expect(wrapper.text()).not.toMatch('Some header');
+      expect(wrapper.text()).not.toMatch('Some footer');
+    });
+
     it(`renders and tracks received content for '${zoneType}' zones`, async (): Promise<void> => {
       const zoneId = '5';
       const extra = { foo: 'bar' };


### PR DESCRIPTION
This slot is for displaying backup content when the zone content is
fetched without error but there is no content to display.
