### PR TITLE
Remove all listeners for the zone on destroy

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -123,7 +123,7 @@ export default class CmsZone extends Vue {
 
   private beforeDestroy(): void {
     this.$root.$off('cms.refresh', this.refresh);
-    this.$root.$off(`cms.refresh.${this.zoneId}`, this.refresh);
+    this.$root.$off(`cms.refresh.${this.zoneId}`);
     this.removeScrollListeners();
   }
 


### PR DESCRIPTION
This fixes a memory leak. The leak works as follows:
 
1. We render a CMS zone. It starts off with **zero** listeners.
2. In `created()`, we listen for events to refresh this zone: https://github.com/propelinc/vue-phoenix/blob/7b8f450937f152fd6e2724cb925a7b6cf1c9a567/src/components/CmsZone.vue#L115-L118 We now have **one** listener for this zone.
2. In `mounted()`, we refresh the zone: https://github.com/propelinc/vue-phoenix/blob/7b8f450937f152fd6e2724cb925a7b6cf1c9a567/src/components/CmsZone.vue#L120-L122
3. After receiving the contents from the server, we call `trackIndex()`: https://github.com/propelinc/vue-phoenix/blob/7b8f450937f152fd6e2724cb925a7b6cf1c9a567/src/components/CmsZone.vue#L214
4. In `trackIndex()`, we add a `$once` to listen for events to refresh this zone. We now have **two** listeners for this zone. https://github.com/propelinc/vue-phoenix/blob/7b8f450937f152fd6e2724cb925a7b6cf1c9a567/src/components/CmsZone.vue#L226-L230
5. I navigate away from this page, which destroys the zone. We remove the listener that we added in `created()`, but the `$once` one is still attached. This brings our count down to **one.** https://github.com/propelinc/vue-phoenix/blob/7b8f450937f152fd6e2724cb925a7b6cf1c9a567/src/components/CmsZone.vue#L124-L128
7. I navigate back to the page, and the zone is recreated. This time, it starts off with **one** listener.
8. Repeat, and the number of listeners will increase.

The fix is to remove **all** listeners for this zone, including the `$once`.