### PR TITLE
Remove event listener to avoid memory leak

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -124,6 +124,7 @@ export default class CmsZone extends Vue {
   private beforeDestroy(): void {
     this.$root.$off('cms.refresh', this.refresh);
     this.$root.$off(`cms.refresh.${this.zoneId}`, this.refresh);
+    this.$root.$off(`cms.track.${this.zoneId}`);
     this.removeScrollListeners();
   }
 

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -123,7 +123,7 @@ export default class CmsZone extends Vue {
 
   private beforeDestroy(): void {
     this.$root.$off('cms.refresh', this.refresh);
-    this.$root.$off(`cms.refresh.${this.zoneId}`);
+    this.$root.$off(`cms.refresh.${this.zoneId}`, this.refresh);
     this.removeScrollListeners();
   }
 


### PR DESCRIPTION
We never removed the `track` listener, which emits a refresh, resulting in multiple tracks and refreshes. I mistook `cms.track` for `cms.refresh` in my previous PR.