### PR TITLE
Wait to track before refreshing

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -225,10 +225,13 @@ export default class CmsZone extends Vue {
 
     const trackOn = (content.extra || {}).track_on;
     if (trackOn) {
-      this.$root.$once(`cms.track.${this.zoneId}`, (): void => {
-        cmsClient.trackZone({ content, zoneId: this.zoneId });
-        this.$root.$emit(`cms.refresh.${this.zoneId}`);
-      });
+      this.$root.$once(
+        `cms.track.${this.zoneId}`,
+        async (): Promise<void> => {
+          await cmsClient.trackZone({ content, zoneId: this.zoneId });
+          this.$root.$emit(`cms.refresh.${this.zoneId}`);
+        }
+      );
 
       this.$root.$once('router.change', (hash: string): void => {
         const regex = new RegExp(trackOn);


### PR DESCRIPTION
Without this, we track the impression and refresh the zone concurrently, and so there's a race condition where the zone refresh uses the old captable before the track response comes back. When that happens, the zone response overwrites the updated captable.