### PR TITLE
fix long running carousel reload issue

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -198,8 +198,7 @@ export default class CmsZone extends Vue {
       ? `<div class="zone-footer">${data.zone_footer || ''}</div>`
       : '';
     this.zoneStatus = null;
-    // Increment nonce after contents are set to ensure a new carousel is created.
-    // If not, the carousel component breaks when you change the existing contents.
+    // Circumvent issue where carousel breaks by forcing it to re-render
     this.nonce++;
 
     if (!this.contents.length) {

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -17,6 +17,7 @@
       />
       <cms-carousel
         v-if="zoneType === 'carousel'"
+        :key="`${nonce}-${zoneId}`"
         :center-padding="contents.length > 1 ? '20px' : '0'"
         :zone-id="zoneId"
         @change="trackIndex"
@@ -197,6 +198,9 @@ export default class CmsZone extends Vue {
       ? `<div class="zone-footer">${data.zone_footer || ''}</div>`
       : '';
     this.zoneStatus = null;
+    // Increment nonce after contents are set to ensure a new carousel is created.
+    // If not, the carousel component breaks when you change the existing contents.
+    this.nonce++;
 
     if (!this.contents.length) {
       return;


### PR DESCRIPTION
## Context
https://app.asana.com/0/1114079329865070/1148595595430819

I was able to reproduce the behavior, in the browser app, by just changing the content in the cms-carousel while the carousel was still on screen. 

I tracked the issue down to the [vue-slick](https://github.com/staskjs/vue-slick) component. It seems to just break if you update the content. I added a pattern I see other places in this file, of using the `nonce` to ensure a new vue object is created on each request. 

Example of it working:
Screen shot before backgrounding the app:
![image](https://user-images.githubusercontent.com/3281726/111854257-a1a0cd80-88f4-11eb-81bf-750cf57f4fc3.png)

video of foregrounding the app and not seeing the bug:

https://user-images.githubusercontent.com/3281726/111855551-dbc19d80-88fb-11eb-87ff-13d88081e10e.mov




**List of concerning things:**
* Has this ever worked??? This seems like we might just be missing a huge opportunity to show folks more content?
* vue-slick is no longer maintained. 