### PR TITLE
[Hackathon] Zone map + inspector

### DIFF
--- a/src/components/CmsInspectSheet.vue
+++ b/src/components/CmsInspectSheet.vue
@@ -1,0 +1,224 @@
+<template>
+  <div v-if="value" @click.stop="">
+    <div class="cms-inspect-sheet-scrim" @click="$emit('input', false)" />
+    <div class="cms-inspect-sheet">
+      <div class="cms-inspect-sheet__header">
+        <h4 class="cms-inspect-sheet__header__title">Zone {{ zoneId || 'default' }}</h4>
+      </div>
+
+      <div class="cms-inspect-sheet__body">
+        <div class="cms-inspect-sheet__section">
+          <h4>Basics</h4>
+          <div class="cms-inspect-sheet__row">
+            <div class="cms-inspect-sheet__row__label">Zone Type</div>
+            <div class="cms-inspect-sheet__row__value">{{ zoneType }}</div>
+          </div>
+          <div class="cms-inspect-sheet__row">
+            <div class="cms-inspect-sheet__row__label">Zone Status</div>
+            <div class="cms-inspect-sheet__row__value">{{ zoneStatus || 'normal' }}</div>
+          </div>
+
+          <button class="cms-inspect-sheet__button" @click="refreshZone">Refresh</button>
+        </div>
+
+        <div class="cms-inspect-sheet__section">
+          <h4>Deliveries</h4>
+          <template v-if="contents.length > 0">
+            <div v-for="(content, index) in contents" :key="index" class="cms-inspect-sheet__row">
+              <div class="cms-inspect-sheet__row__label">Delivery {{ content.delivery }}</div>
+              <div class="cms-inspect-sheet__row__value">
+                <a target="_blank" :href="getDeliveryAdminLink(content.delivery)">View in admin</a>
+              </div>
+            </div>
+          </template>
+          <div v-else>Nothing was delivered to this zone.</div>
+        </div>
+
+        <div class="cms-inspect-sheet__section">
+          <h4>Context</h4>
+          <template v-if="renderContextEntries.length > 0">
+            <div>This zone has access to the following extra fields in the CMS template:</div>
+            <div
+              v-for="(entry, index) in renderContextEntries"
+              :key="index"
+              class="cms-inspect-sheet__row"
+            >
+              <div class="cms-inspect-sheet__row__label">{{ entry[0] }}</div>
+              <div class="cms-inspect-sheet__row__value">{{ entry[1] }}</div>
+            </div>
+          </template>
+          <div v-else>There are no additional fields for this zone.</div>
+        </div>
+
+        <div class="cms-inspect-sheet__section">
+          <h4>Sitevars</h4>
+          <div>These variables are shared across all zones:</div>
+          <div v-for="(entry, index) in siteVarEntries" :key="index" class="cms-inspect-sheet__row">
+            <div class="cms-inspect-sheet__row__label">{{ entry[0] }}</div>
+            <div class="cms-inspect-sheet__row__value">{{ entry[1] }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="cms-inspect-sheet__footer">
+        <a class="cms-inspect-sheet__button" target="_blank" :href="zoneAdminLink">
+          View in admin
+        </a>
+        <button
+          class="cms-inspect-sheet__button cms-inspect-sheet__button--text"
+          @click="$emit('input', false)"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+import { Content } from '../api';
+import { pluginOptions } from '../plugins/cms';
+
+@Component
+export default class CmsInspectSheet extends Vue {
+  @Prop({ type: Boolean, default: false }) value!: boolean;
+  @Prop({ type: String, required: true }) zoneId!: string;
+  @Prop({ type: String }) zoneStatus?: string;
+  @Prop({ type: String }) zoneType?: string;
+  @Prop({ type: String }) zoneHeader?: string;
+  @Prop({ type: String }) zoneFooter?: string;
+  @Prop(Object) renderContext?: object;
+  @Prop({ type: Array, default: () => [] }) contents!: Content[];
+
+  siteVars = {};
+
+  created(): void {
+    this.siteVars = pluginOptions.getSiteVars();
+  }
+
+  get zoneAdminLink(): string {
+    return `${pluginOptions.baseUrl}/admin/zone/edit/?id=64`;
+  }
+
+  get siteVarEntries() {
+    return Object.entries(this.siteVars).filter((entry) => {
+      return entry[1] !== undefined && entry[1] !== null && entry[1] !== '';
+    });
+  }
+
+  get renderContextEntries() {
+    return Object.entries(this.renderContext || {}).filter((entry) => {
+      return entry[1] !== undefined && entry[1] !== null;
+    });
+  }
+
+  getDeliveryAdminLink(deliveryId: number): string {
+    return `${pluginOptions.baseUrl}/admin/delivery/?flt0_0=${deliveryId}`;
+  }
+
+  refreshZone(): void {
+    this.$root.$emit(`cms.refresh.${this.zoneId}`);
+  }
+}
+</script>
+
+<style lang="less" scoped>
+@cms-inspect-sheet-border: 1px solid #d1d3d7;
+
+.cms-inspect-sheet-scrim {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+  background: fade(black, 45%);
+}
+
+.cms-inspect-sheet {
+  position: fixed;
+  color: black;
+  z-index: 101;
+  background: white;
+  border-radius: 8px 8px 0 0;
+  top: 72px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+}
+
+.cms-inspect-sheet__header {
+  padding: 8px 16px;
+  flex: none;
+  border-bottom: @cms-inspect-sheet-border;
+}
+
+.cms-inspect-sheet__header__title {
+  font-weight: bold;
+  text-align: center;
+}
+
+.cms-inspect-sheet__body {
+  padding: 8px 16px;
+  overflow: scroll;
+  flex: auto;
+}
+
+.cms-inspect-sheet__section {
+  & + & {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: @cms-inspect-sheet-border;
+  }
+}
+
+.cms-inspect-sheet__footer {
+  border-top: @cms-inspect-sheet-border;
+  flex: none;
+  padding: 8px 16px;
+}
+
+.cms-inspect-sheet__button {
+  background-color: #5560cb;
+  color: white;
+  border-radius: 4px;
+  width: 100%;
+  display: block;
+  text-align: center;
+  padding: 8px 16px;
+}
+
+.cms-inspect-sheet__button--text {
+  background: transparent;
+  color: #5560cb;
+}
+
+.cms-inspect-sheet__row {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+
+  & + & {
+    border-top: @cms-inspect-sheet-border;
+  }
+}
+
+.cms-inspect-sheet__row__label {
+  font-weight: bold;
+  flex: auto;
+}
+
+.cms-inspect-sheet__row__value {
+  text-align: right;
+  flex: auto;
+  margin-left: 16px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+</style>

--- a/src/components/CmsInspectSheet.vue
+++ b/src/components/CmsInspectSheet.vue
@@ -3,18 +3,18 @@
     <div class="cms-inspect-sheet-scrim" @click="$emit('input', false)" />
     <div class="cms-inspect-sheet">
       <div class="cms-inspect-sheet__header">
-        <h4 class="cms-inspect-sheet__header__title">Zone {{ zoneId || 'default' }}</h4>
+        <h4 class="cms-inspect-sheet__header__title">Zone {{ zoneId }}</h4>
       </div>
 
       <div class="cms-inspect-sheet__body">
         <div class="cms-inspect-sheet__section">
           <h4>Basics</h4>
           <div class="cms-inspect-sheet__row">
-            <div class="cms-inspect-sheet__row__label">Zone Type</div>
-            <div class="cms-inspect-sheet__row__value">{{ zoneType }}</div>
+            <div class="cms-inspect-sheet__row__label">Type</div>
+            <div class="cms-inspect-sheet__row__value">{{ zoneType || 'default'  }}</div>
           </div>
           <div class="cms-inspect-sheet__row">
-            <div class="cms-inspect-sheet__row__label">Zone Status</div>
+            <div class="cms-inspect-sheet__row__label">Status</div>
             <div class="cms-inspect-sheet__row__value">{{ zoneStatus || 'normal' }}</div>
           </div>
 

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -1,8 +1,25 @@
 <template>
   <div
     v-infinite-scroll="{ action: next, enabled: isScrolling }"
-    :class="{ 'scrollable-content': isScrolling }"
+    :class="{ 'scrollable-content': isScrolling, 'cms-zone--inspect': isInspectOverlayEnabled }"
   >
+    <button
+      v-if="isInspectOverlayEnabled"
+      class="cms-zone__zone-label"
+      @click.stop.prevent="shouldShowInspectModal = true"
+    >
+      Zone <strong>{{ zoneId }}</strong>
+    </button>
+
+    <cms-inspect-sheet
+      v-model="shouldShowInspectModal"
+      :zone-id="zoneId"
+      :render-context="renderContext"
+      :contents="contents"
+      :zone-status="zoneStatus"
+      :zone-type="zoneType"
+    />
+
     <slot v-if="!zoneType && !contents.length" />
     <slot v-if="zoneStatus === 'error'" name="error" />
     <slot v-if="zoneStatus === 'offline'" name="offline" />
@@ -66,6 +83,7 @@ import { pluginOptions } from '../plugins/cms';
 
 import CmsCarousel from './CmsCarousel.vue';
 import CmsContent from './CmsContent';
+import CmsInspectSheet from './CmsInspectSheet.vue';
 
 const durationVisibleToBeTrackedMs = 1000;
 const percentVisible = 50;
@@ -82,7 +100,7 @@ export function getClosest(elm: Element, selector: string): HTMLElement | null {
 
 @Component({
   name: 'cms-zone',
-  components: { CmsCarousel, CmsContent },
+  components: { CmsCarousel, CmsContent, CmsInspectSheet },
 })
 export default class CmsZone extends Vue {
   @Prop(String) public zoneId!: string;
@@ -101,6 +119,8 @@ export default class CmsZone extends Vue {
   public nonce: number = 0;
   public cursorLoading: boolean = false;
   public next = debounce(() => this.getNextPage(), 400);
+
+  shouldShowInspectModal = false;
 
   private get isScrolling() {
     return this.zoneType === 'scrolling';
@@ -340,6 +360,10 @@ export default class CmsZone extends Vue {
     const visibleHeight = elHeight - invisibleHeight;
     return (visibleHeight / elHeight) * 100 >= minPercentVisible;
   }
+
+  get isInspectOverlayEnabled(): boolean {
+    return this.$cms.isInspectOverlayEnabled;
+  }
 }
 </script>
 
@@ -363,5 +387,38 @@ export default class CmsZone extends Vue {
   position: relative; /* need this to position inner content */
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+}
+</style>
+
+<style lang="less" scoped>
+.cms-zone--inspect {
+  border: 2px solid #a3b0f9;
+
+  .cms-zone__zone-label {
+    background: fade(#a3b0f9, 70%);
+  }
+
+  & & {
+    border: 2px solid #b3f6a2;
+
+    .cms-zone__zone-label {
+      background: fade(#b3f6a2, 70%);
+    }
+  }
+
+  & & & {
+    border: 2px solid #fdcab7;
+
+    .cms-zone__zone-label {
+      background: fade(#fdcab7, 70%);
+    }
+  }
+}
+
+.cms-zone__zone-label {
+  padding: 4px 8px;
+  white-space: nowrap;
+  font-size: 12px;
+  color: black;
 }
 </style>

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -8,7 +8,7 @@
       class="cms-zone__zone-label"
       @click.stop.prevent="shouldShowInspectModal = true"
     >
-      Zone <strong>{{ zoneId }}</strong>
+      {{ zoneId }}
     </button>
 
     <cms-inspect-sheet
@@ -429,5 +429,8 @@ export default class CmsZone extends Vue {
   white-space: nowrap;
   font-size: 12px;
   color: black;
+  font-weight: bold;
+  min-width: 40px;
+  backdrop-filter: blur(1px);
 }
 </style>

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -42,8 +42,11 @@
         <cms-content
           v-for="(content, index) in contents"
           :key="`${nonce}-${content.delivery}`"
-          :class="`cms-zone-content-${zoneId}-${index}`"
-          class="cms-zone-carousel-content"
+          :class="{
+            [`cms-zone-content-${zoneId}-${index}`]: true,
+            'cms-zone-content--tracked': content.tracked,
+          }"
+          class="cms-zone-content cms-zone-carousel-content"
           tag="div"
           :html="content.html"
           :context="renderContext"
@@ -54,7 +57,11 @@
         <cms-content
           v-for="(content, index) in contents"
           :key="`${nonce}-${content.delivery}`"
-          :class="`cms-zone-content-${zoneId}-${index}`"
+          class="cms-zone-content"
+          :class="{
+            [`cms-zone-content-${zoneId}-${index}`]: true,
+            'cms-zone-content--tracked': content.tracked,
+          }"
           tag="div"
           :html="content.html"
           :context="renderContext"
@@ -244,7 +251,7 @@ export default class CmsZone extends Vue {
     if (!content || content.tracked) {
       return;
     }
-    content.tracked = true;
+    Vue.set(this.contents, index, { ...content, tracked: true });
 
     const trackOn = (content.extra || {}).track_on;
     if (trackOn) {
@@ -277,7 +284,6 @@ export default class CmsZone extends Vue {
           const contentElm = this.$el.querySelector('.slick-current');
           if (contentElm && this.isContentVisible(contentElm, scrollable, percentVisible)) {
             this.trackIndex(0);
-            contentElm.classList.add('content-viewable-tracked');
             scrollable.removeEventListener('scroll', listener);
           }
         }, durationVisibleToBeTrackedMs);
@@ -296,7 +302,6 @@ export default class CmsZone extends Vue {
           const contentElm = this.$el.querySelector(`.cms-zone-content-${this.zoneId}-${i}`);
           if (contentElm && this.isContentVisible(contentElm, scrollable, percentVisible)) {
             this.trackIndex(i);
-            contentElm.classList.add('content-viewable-tracked');
             scrollable.removeEventListener('scroll', listener);
           }
         }, durationVisibleToBeTrackedMs);
@@ -391,27 +396,31 @@ export default class CmsZone extends Vue {
 </style>
 
 <style lang="less" scoped>
-.cms-zone--inspect {
-  border: 2px solid #a3b0f9;
+.zone-inspect-overlay(@color-light, @color-dark) {
+  border: 1px solid @color-dark;
 
   .cms-zone__zone-label {
-    background: fade(#a3b0f9, 70%);
+    background: fade(@color-light, 70%);
   }
 
-  & & {
-    border: 2px solid #b3f6a2;
+  .cms-zone-content {
+    border: 1px dashed @color-light;
 
-    .cms-zone__zone-label {
-      background: fade(#b3f6a2, 70%);
+    &.cms-zone-content--tracked {
+      border-style: solid;
     }
+  }
+}
+
+.cms-zone--inspect {
+  .zone-inspect-overlay(#a3b0f9, #5560cb);
+
+  & & {
+    .zone-inspect-overlay(#b3f6a2, #51d156);
   }
 
   & & & {
-    border: 2px solid #fdcab7;
-
-    .cms-zone__zone-label {
-      background: fade(#fdcab7, 70%);
-    }
+    .zone-inspect-overlay(#fdcab7, #FC8247);
   }
 }
 

--- a/src/plugins/cms.ts
+++ b/src/plugins/cms.ts
@@ -9,6 +9,7 @@ import CmsServerRequest from '../components/CmsServerRequest.vue';
 import CmsZone from '../components/CmsZone.vue';
 import { ContentFor, YieldTo } from '../components/capture';
 import { addDirectives } from '../directives';
+import installService from '../services/cms';
 
 interface DestroyHTMLElement extends HTMLElement {
   $destroy: () => void;
@@ -67,6 +68,8 @@ export const pluginOptions: PluginOptions = {
 export let finalPluginOptions: PluginOptions;
 
 const plugin = function install(Vue: typeof _Vue, options?: CmsPluginOptions) {
+  installService(Vue);
+
   Object.assign(pluginOptions, options);
   Vue.component('YieldTo', YieldTo);
   Vue.component('ContentFor', ContentFor);

--- a/src/services/cms.ts
+++ b/src/services/cms.ts
@@ -1,0 +1,21 @@
+import _Vue from 'vue';
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $cms: CmsService;
+  }
+}
+
+class CmsService {
+  isInspectOverlayEnabled: boolean = false;
+
+  changeInspectMode(enabled: boolean): void {
+    this.isInspectOverlayEnabled = enabled;
+  }
+}
+
+const cmsService = _Vue.observable(new CmsService());
+
+export default function installService(Vue: typeof _Vue): void {
+  Vue.prototype.$cms = cmsService;
+}

--- a/tests/unit/CmsZone.spec.ts
+++ b/tests/unit/CmsZone.spec.ts
@@ -229,55 +229,82 @@ describe('CmsZone.vue', (): void => {
       expect(cmsClient.trackZone).toHaveBeenCalled();
     });
   });
-});
 
-describe('CmsZone.vue isContentVisible tests:', (): void => {
-  let cms: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  describe('inspector overlay', () => {
+    it('does not render inspect overlay by default', () => {
+      const wrapper = shallowMount(CmsZone, {
+        localVue,
+        propsData: { zoneId: '1' },
+      });
 
-  function getElementWithRect(height: number, top: number, bottom: number): Element {
-    const element = document.createElement('div');
-    (element as any).getBoundingClientRect = () => ({ height, top, bottom }); // eslint-disable-line @typescript-eslint/no-explicit-any
-    return element;
-  }
-
-  beforeEach((): void => {
-    const wrapper = shallowMount(CmsZone, {
-      localVue,
-      propsData: { zoneId: '5' },
+      expect(wrapper.find('.cms-zone--inspect').exists()).toBe(false);
+      expect(wrapper.find('.cms-zone__zone-label').exists()).toBe(false);
     });
-    cms = wrapper.vm;
+
+    it('can render the inspect overlay', () => {
+      const wrapper = shallowMount(CmsZone, {
+        localVue,
+        propsData: { zoneId: '15' },
+        mocks: {
+          $cms: {
+            isInspectOverlayEnabled: true,
+          },
+        },
+      });
+
+      expect(wrapper.find('.cms-zone--inspect').exists()).toBe(true);
+      expect(wrapper.find('.cms-zone__zone-label').text()).toBe('Zone 15');
+    });
   });
 
-  it('should only be visible when completely in view', (): void => {
-    let el = getElementWithRect(10, 20, 30);
-    let viewport = getElementWithRect(20, 0, 20);
-    expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
+  describe('isContentVisible', (): void => {
+    let cms: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    el = getElementWithRect(10, 11, 21);
-    viewport = getElementWithRect(20, 0, 20);
-    expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
+    function getElementWithRect(height: number, top: number, bottom: number): Element {
+      const element = document.createElement('div');
+      (element as any).getBoundingClientRect = () => ({ height, top, bottom }); // eslint-disable-line @typescript-eslint/no-explicit-any
+      return element;
+    }
 
-    el = getElementWithRect(10, 10, 20);
-    viewport = getElementWithRect(20, 0, 20);
-    expect(cms.isContentVisible(el, viewport, 100)).toBe(true);
+    beforeEach((): void => {
+      const wrapper = shallowMount(CmsZone, {
+        localVue,
+        propsData: { zoneId: '5' },
+      });
+      cms = wrapper.vm;
+    });
 
-    el = getElementWithRect(10, 0, 10);
-    viewport = getElementWithRect(20, 0, 20);
-    expect(cms.isContentVisible(el, viewport, 100)).toBe(true);
+    it('should only be visible when completely in view', (): void => {
+      let el = getElementWithRect(10, 20, 30);
+      let viewport = getElementWithRect(20, 0, 20);
+      expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
 
-    el = getElementWithRect(10, -1, 9);
-    viewport = getElementWithRect(20, 0, 20);
-    expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
+      el = getElementWithRect(10, 11, 21);
+      viewport = getElementWithRect(20, 0, 20);
+      expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
 
-    el = getElementWithRect(10, -10, 0);
-    viewport = getElementWithRect(20, 0, 20);
-    expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
-  });
+      el = getElementWithRect(10, 10, 20);
+      viewport = getElementWithRect(20, 0, 20);
+      expect(cms.isContentVisible(el, viewport, 100)).toBe(true);
 
-  it('should be visible when the minimum percentage is met', (): void => {
-    const el = getElementWithRect(10, 19, 29);
-    const viewport = getElementWithRect(20, 0, 20);
-    expect(cms.isContentVisible(el, viewport, 10)).toBe(true);
-    expect(cms.isContentVisible(el, viewport, 11)).toBe(false);
+      el = getElementWithRect(10, 0, 10);
+      viewport = getElementWithRect(20, 0, 20);
+      expect(cms.isContentVisible(el, viewport, 100)).toBe(true);
+
+      el = getElementWithRect(10, -1, 9);
+      viewport = getElementWithRect(20, 0, 20);
+      expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
+
+      el = getElementWithRect(10, -10, 0);
+      viewport = getElementWithRect(20, 0, 20);
+      expect(cms.isContentVisible(el, viewport, 100)).toBe(false);
+    });
+
+    it('should be visible when the minimum percentage is met', (): void => {
+      const el = getElementWithRect(10, 19, 29);
+      const viewport = getElementWithRect(20, 0, 20);
+      expect(cms.isContentVisible(el, viewport, 10)).toBe(true);
+      expect(cms.isContentVisible(el, viewport, 11)).toBe(false);
+    });
   });
 });

--- a/tests/unit/CmsZone.spec.ts
+++ b/tests/unit/CmsZone.spec.ts
@@ -253,7 +253,7 @@ describe('CmsZone.vue', (): void => {
       });
 
       expect(wrapper.find('.cms-zone--inspect').exists()).toBe(true);
-      expect(wrapper.find('.cms-zone__zone-label').text()).toBe('Zone 15');
+      expect(wrapper.find('.cms-zone__zone-label').text()).toBe('15');
     });
   });
 


### PR DESCRIPTION
I've heard a lot of requests for a zone map from designers + other non-engineering people who work with the CMS. I think the best way for us to keep something like that up to date is to have the zones document themselves. 

This PR exposes a new CMS service that we can access in the host app as `this.$cms`. The first piece of functionality on this service is the zone map. Zones can now show an outline and a label w/ their ID so we can see all the zones in an app. I've also added a sheet that appears when you tap the label that gives some more information on the zone.

![zone map](https://user-images.githubusercontent.com/12708879/112515603-c968b900-8d6c-11eb-99bb-5c5e4e18c7bb.gif)

It also shows when zones have been tracked: 

![zone tracking](https://user-images.githubusercontent.com/12708879/112547672-6fc6b580-8d91-11eb-874b-eab820c6f291.gif)
