### PR TITLE
change scroll rules back to what they were

### DIFF
--- a/src/directives.ts
+++ b/src/directives.ts
@@ -39,7 +39,8 @@ function setupInfiniteScroll(el: DestroyHTMLElement, binding: DirectiveBinding) 
   const action = params.action;
 
   const handler = (): void => {
-    if (el.scrollTop >= el.clientHeight - tolerance) {
+    const height = (el.firstChild as DestroyHTMLElement).clientHeight;
+    if (el.scrollTop >= height - el.clientHeight - tolerance) {
       action();
     }
   };

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -39,12 +39,15 @@ function setupInfiniteScroll(el: DestroyHTMLElement, binding: DirectiveBinding) 
   const action = params.action;
 
   const handler = (): void => {
-    let height = 0;
     if (el.firstChild) {
-      height = (el.firstChild as HTMLElement).clientHeight;
-    }
-    if (el.scrollTop >= height - el.clientHeight - tolerance) {
-      action();
+      const height = (el.firstChild as HTMLElement).clientHeight;
+      if (el.scrollTop >= height - el.clientHeight - tolerance) {
+        action();
+      }
+    } else {
+      if (el.scrollTop >= el.clientHeight - tolerance) {
+        action();
+      }
     }
   };
 

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -40,7 +40,7 @@ function setupInfiniteScroll(el: DestroyHTMLElement, binding: DirectiveBinding) 
 
   const handler = (): void => {
     if (el.firstChild) {
-      const height = (el.firstChild as HTMLElement).clientHeight;
+      const height = (el.firstChild as HTMLElement).clientHeight || 0;
       if (el.scrollTop >= height - el.clientHeight - tolerance) {
         action();
       }

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -39,7 +39,10 @@ function setupInfiniteScroll(el: DestroyHTMLElement, binding: DirectiveBinding) 
   const action = params.action;
 
   const handler = (): void => {
-    const height = (el.firstChild as DestroyHTMLElement).clientHeight;
+    let height = 0;
+    if (el.firstChild) {
+      height = (el.firstChild as HTMLElement).clientHeight;
+    }
     if (el.scrollTop >= height - el.clientHeight - tolerance) {
       action();
     }


### PR DESCRIPTION
## Context
Asana card: https://app.asana.com/0/1199612650951166/1200204191780112

We discovered a [huge jump in `job - search attempt` amplitude events](https://analytics.amplitude.com/propel/chart/new/t7h9k6s) starting on december 9th. The cause seems to be that the infinite scroll on the `/jobs` is not functioning as expected. 

Expected behavior: When you get to the bottom of the jobs page, only the next set of jobs loads
Action behavior: When you get to the bottom of the jobs page it pages through all of the rest of the jobs till there are no more jobs to display. 

This fix is based on the changes [made in this PR]

![image](https://user-images.githubusercontent.com/3281726/116474976-30cfc800-a847-11eb-93b7-8b21a659deec.png)

![image](https://user-images.githubusercontent.com/3281726/116475009-39c09980-a847-11eb-8d77-cedf9eb76b31.png)
