### PR TITLE
Add Search and Filter functionality

### DIFF
--- a/src/cmsHttp.ts
+++ b/src/cmsHttp.ts
@@ -117,6 +117,13 @@ class CmsClient {
 
     await this.http({ zoneId, url: content.tracker });
   }
+
+  async fetchFilterCategories(zoneId: string) {
+    return this.http({
+      zoneId,
+      url: `/cms/zone/${zoneId}/categories`,
+    });
+  }
 }
 
 export default new CmsClient();

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -27,6 +27,7 @@
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
     <slot v-if="!zoneStatus && !contents.length" name="empty" />
+    <slot name="search-header" />
     <div v-if="contents.length">
       <cms-content
         v-if="zoneHeader"

--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -27,7 +27,7 @@
     <slot v-if="zoneStatus === 'offline'" name="offline" />
     <slot v-if="zoneStatus === 'loading'" name="loading" />
     <slot v-if="!zoneStatus && !contents.length" name="empty" />
-    <slot name="search-header" />
+    <slot v-if="displaySearchHeader" name="search-header" />
     <div v-if="contents.length">
       <cms-content
         v-if="zoneHeader"
@@ -396,6 +396,10 @@ export default class CmsZone extends Vue {
 
   get isInspectOverlayEnabled(): boolean {
     return this.$cms.isInspectOverlayEnabled;
+  }
+
+  get displaySearchHeader(): boolean {
+    return !!(this.contents.length || 'q' in this.extra || 'category' in this.extra);
   }
 }
 </script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "suppressImplicitAnyIndexErrors": true,
     "resolveJsonModule": true,
+    "downlevelIteration": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [


### PR DESCRIPTION
In this PR we add logic for a new cms request for the filtering categories for a specific zone, a new search header slot to the html, and a function to determine whether the search header should be shown. 

This PR is a companion to [this PR](https://github.com/propelinc/freshebt-vue/compare/chuckst-search_filter?expand=1). 

