### PR TITLE
Fix link to zone in cms admin

### DIFF
--- a/src/components/CmsInspectSheet.vue
+++ b/src/components/CmsInspectSheet.vue
@@ -99,7 +99,7 @@ export default class CmsInspectSheet extends Vue {
   }
 
   get zoneAdminLink(): string {
-    return `${pluginOptions.baseUrl}/admin/zone/edit/?id=64`;
+    return `${pluginOptions.baseUrl}/admin/zone/edit/?id=${this.zoneId}`;
   }
 
   get siteVarEntries() {


### PR DESCRIPTION
When you turn on the cms inspector option, you can click on each zone to bring up the "cms inspect sheet". This sheet has a link that's supposed to open the cms admin to that zone. Accidentally hard coded it to zone 64 the first time around.