### PR TITLE
Make setup function in CmsContent work in preview mode.

### DIFF
--- a/src/components/CmsContent.ts
+++ b/src/components/CmsContent.ts
@@ -48,6 +48,11 @@ export default class CmsContent extends Vue {
     }
   }
 
+  @Watch('html')
+  private resetSetup(): void {
+    this.setupComplete = false;
+  }
+
   private render(h: CreateElement): VNode {
     if (!this.html) {
       return h('div', this.$slots.default);

--- a/tests/unit/CmsContent.spec.ts
+++ b/tests/unit/CmsContent.spec.ts
@@ -70,6 +70,17 @@ describe('CmsContent.ts', (): void => {
     expect(wrapper.text()).toMatch('Content 5');
   });
 
+  it('re-initialize is allowed when the html updates', async (): Promise<void> => {
+    const html = '<div :run="setup({k: 5})">Content {{ context.k }}</div>';
+    const wrapper = mount(CmsContent, { localVue, propsData: { html } });
+    await Vue.nextTick();
+    expect(wrapper.text()).toMatch('Content 5');
+
+    wrapper.vm.html = '<div :run="setup({k: 2})">Content {{ context.k }}</div>';
+    await Vue.nextTick();
+    expect(wrapper.text()).toMatch('Content 2');
+  });
+
   it('tracks analytics events', async (): Promise<void> => {
     pluginOptions.trackAnalytics = jest.fn();
     const html = `<div :run="setup({k: 5})"><div :run="track('foo', context)">Foo</div></div>`;


### PR DESCRIPTION
The `setup` funciton is intended to be a replacement for v-init. It does not work as expected in the cms preview as the setup is already complete. This change resets the state when the html is updated to get around this.