### PR TITLE
adding sitevars to fetchCategories request

### DIFF
--- a/src/cmsHttp.ts
+++ b/src/cmsHttp.ts
@@ -122,6 +122,9 @@ class CmsClient {
     return this.http({
       zoneId,
       url: `/cms/zone/${zoneId}/categories`,
+      params: {
+        ...pluginOptions.getSiteVars(),
+      },
     });
   }
 }


### PR DESCRIPTION
In QAing the search and filter feature, Jacob realized that there were times that we weren't returning all of the categories for a specific zone, just a subset. After digging in a bit, I realized that the fetchZone call was was finding one set of deliveries and returning the content associated with those deliveries. The fetchCategories call was only finding a subset of those the fetchZone deliveries and as a result was only returning categories for that subset. The server side implementation of fetchZone and fetchCategories are identical in all relevant areas, and so I realized it was that the calls to each had to differ. And so, here we are with a fix. Adding sitevars to the fetchCategories request makes it so the exact same deliveries are found and processed by both routes.