### PR TITLE
Add new option for admin URL

### DIFF
--- a/src/components/CmsInspectSheet.vue
+++ b/src/components/CmsInspectSheet.vue
@@ -99,7 +99,7 @@ export default class CmsInspectSheet extends Vue {
   }
 
   get zoneAdminLink(): string {
-    return `${pluginOptions.baseUrl}/admin/zone/edit/?id=${this.zoneId}`;
+    return `${pluginOptions.adminUrl}/admin/zone/edit/?id=${this.zoneId}`;
   }
 
   get siteVarEntries() {
@@ -115,7 +115,7 @@ export default class CmsInspectSheet extends Vue {
   }
 
   getDeliveryAdminLink(deliveryId: number): string {
-    return `${pluginOptions.baseUrl}/admin/delivery/?flt0_0=${deliveryId}`;
+    return `${pluginOptions.adminUrl}/admin/delivery/?flt0_0=${deliveryId}`;
   }
 
   refreshZone(): void {

--- a/src/plugins/cms.ts
+++ b/src/plugins/cms.ts
@@ -18,6 +18,7 @@ interface DestroyHTMLElement extends HTMLElement {
 
 export interface CmsPluginOptions {
   baseUrl?: string;
+  adminUrl?: string;
   globalCssCacheMs?: number;
   router?: Router;
 
@@ -37,6 +38,7 @@ export interface CmsPluginOptions {
 
 export interface PluginOptions extends CmsPluginOptions {
   baseUrl: string;
+  adminUrl: string;
   checkConnection: () => boolean;
   getCaptable: () => Captable;
   getSiteVars: () => object;
@@ -48,6 +50,7 @@ export interface PluginOptions extends CmsPluginOptions {
 
 export const pluginOptions: PluginOptions = {
   baseUrl: '.',
+  adminUrl: '.',
   globalCssCacheMs: 2 * 60 * 1000,
   checkConnection() {
     return navigator.onLine;


### PR DESCRIPTION
Now that our admin has moved from easyfoodstamps.com to **admin.**easyfoodstamps.com, we can't just use the base URL for links in the inspect sheet. This adds a new field to the plugin options, so apps can specify the correct URL.