### PR TITLE
Fix impression tracking for all zone types

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -362,7 +362,9 @@ export default class CmsZone extends Vue {
     } finally {
       // Circumvent issue where carousel breaks by forcing it to re-render
       this.nonce++;
+      await Vue.nextTick();
       this.zoneObserverManager.disconnect(this);
+      this.setupTracking(this.contents);
     }
   }
 
@@ -425,13 +427,11 @@ export default class CmsZone extends Vue {
     if (zoneId !== this.zoneId) {
       return;
     }
-
     this.lastResponse = response.data;
     if (this.refreshing) {
       this.contents = this.lastResponse.content;
       this.refreshing = false;
-    }
-    else {
+    } else {
       this.contents.push(...this.lastResponse.content);
     }
     await Vue.nextTick();

--- a/tests/unit/CmsZone.spec.ts
+++ b/tests/unit/CmsZone.spec.ts
@@ -153,6 +153,7 @@ describe('CmsZone.vue', (): void => {
       await response;
       await localVue.nextTick();
       await localVue.nextTick();
+      await localVue.nextTick();
 
       jest.runOnlyPendingTimers();
       expect(cmsClient.trackZone).toHaveBeenCalled();
@@ -184,6 +185,7 @@ describe('CmsZone.vue', (): void => {
       );
       const wrapper = mount(component, { localVue });
       await response;
+      await localVue.nextTick();
       await localVue.nextTick();
       await localVue.nextTick();
 
@@ -218,6 +220,7 @@ describe('CmsZone.vue', (): void => {
       );
 
       await response;
+      await localVue.nextTick();
       await localVue.nextTick();
       await localVue.nextTick();
       jest.runOnlyPendingTimers();
@@ -255,6 +258,7 @@ describe('CmsZone.vue', (): void => {
 
       const wrapper = mount(component, { localVue });
       await response;
+      await localVue.nextTick();
       await localVue.nextTick();
       await localVue.nextTick();
       jest.runOnlyPendingTimers();


### PR DESCRIPTION
I found that [this line](https://github.com/propelinc/vue-phoenix/blob/4b0c54d3de933c211e431e4f0f5be9ddfdf9beba/src/components/CmsZone.vue#L365) was turning off the observer immediately after fetching the content.

I'm not familiar with the issue in the comment here, but it seems like the line to set tracking back up was just lost so I added that back in: https://github.com/propelinc/vue-phoenix/pull/49/files#diff-8432f53e8ab0ff54c110e2ced3c595724afaf03fdf531a9c1bb18006b916d6feL324-L330

Now all of the tracking requests (/cms/beacon) seem to be coming in:
![image](https://user-images.githubusercontent.com/57370862/151648814-b8bc5841-b443-4f62-8a86-140c8ae8ed3e.png)
