### PR TITLE
Fix bug where we append to content for non-scrolling zones.

### DIFF
--- a/src/components/CmsZone.vue
+++ b/src/components/CmsZone.vue
@@ -209,7 +209,6 @@ export default class CmsZone extends Vue {
   contents: Content[] = [];
   observed: Element[] = [];
   shouldShowInspectModal = false;
-  refreshing = false;
 
   nonce: number = 0;
   cursorLoading: boolean = false;
@@ -227,6 +226,7 @@ export default class CmsZone extends Vue {
     try {
       while (!this.haltPaging && !this.allContentLoaded) {
         const newContents = await this.getNextPage();
+        this.contents.push(...newContents);
 
         // Wait for vue to insert new elements into the DOM.
         await Vue.nextTick();
@@ -344,7 +344,6 @@ export default class CmsZone extends Vue {
     this.haltPaging = false;
     this.cursorLoading = false;
     this.lastResponse = null;
-    this.refreshing = true;
 
     if (!pluginOptions.checkConnection()) {
       this.zoneStatus = 'offline';
@@ -360,7 +359,7 @@ export default class CmsZone extends Vue {
 
   async fetchZone(): Promise<void> {
     try {
-      await this.getNextPage();
+      this.contents = await this.getNextPage();
       this.zoneStatus = null;
 
       // Incrementing the nonce causes all elements to be recreated which
@@ -440,13 +439,6 @@ export default class CmsZone extends Vue {
       return [];
     }
     this.lastResponse = response.data;
-    if (this.refreshing) {
-      this.contents = this.lastResponse.content;
-      this.refreshing = false;
-    } else {
-      this.contents.push(...this.lastResponse.content);
-    }
-
     return this.lastResponse.content;
   }
 


### PR DESCRIPTION
Simplify the logic a bit to guarantee that we only ever append to the content in scrolling zones. Hoping that this will fix: https://propel-team.slack.com/archives/C013DT59JDB/p1643238891657579 .
* The bug was first reported when this commit landed in freshcard-app -> [4b0c54d3de933c211e431e4f0f5be9ddfdf9beba](https://github.com/propelinc/vue-phoenix/commit/4b0c54d3de933c211e431e4f0f5be9ddfdf9beba)
* That's the only place where we append to the `contents` list. Assuming that the CMS configuration is correct, this feels like a possible culprit.
